### PR TITLE
transport: add remote prefix registration 

### DIFF
--- a/src/ndn/app.py
+++ b/src/ndn/app.py
@@ -403,7 +403,7 @@ class NDNApp:
         # Fix the issue that NFD only allows one packet signed by a specific key for a timestamp number
         async with self._prefix_register_semaphore:
             try:
-                _, _, reply = await self.express_interest(make_command('rib', 'register', name=name), lifetime=1000)
+                _, _, reply = await self.express_interest(make_command('rib', 'register', self.face, name=name), lifetime=1000)
                 ret = parse_response(reply)
                 if ret['status_code'] != 200:
                     logging.error(f'Registration for {Name.to_str(name)} failed: '
@@ -427,7 +427,7 @@ class NDNApp:
         name = Name.normalize(name)
         del self._prefix_tree[name]
         try:
-            await self.express_interest(make_command('rib', 'unregister', name=name), lifetime=1000)
+            await self.express_interest(make_command('rib', 'unregister', self.face, name=name), lifetime=1000)
             return True
         except (InterestNack, InterestTimeout, InterestCanceled, ValidationFailure):
             return False

--- a/src/ndn/app_support/nfd_mgmt.py
+++ b/src/ndn/app_support/nfd_mgmt.py
@@ -17,6 +17,8 @@
 # -----------------------------------------------------------------------------
 import struct
 from enum import Enum, Flag
+from typing import Optional
+from ..transport.face import Face
 from ..utils import timestamp, gen_nonce_64
 from ..encoding import Component, Name, ModelField, TlvModel, NameField, UintField, BytesField,\
     SignatureInfo, get_tl_num_size, TypeNumber, write_tl_num, IncludeBase, parse_and_check_tl,\
@@ -225,9 +227,17 @@ class CsInfo(TlvModel):
     n_misses = UintField(0x82)
 
 
-def make_command(module, command, **kwargs):
-    ret = Name.from_str(f"/localhost/nfd/{module}/{command}")
+def make_command(module, command, face = None, **kwargs):
 
+    def isLocalFace(face : Optional[Face]):
+        if not face:
+            return True
+        return face.isLocalFace()
+
+    if isLocalFace(face):
+        ret = Name.from_str(f"/localhost/nfd/{module}/{command}")
+    else:
+        ret = Name.from_str(f"/localhop/nfd/{module}/{command}")
     # Command parameters
     cp = ControlParameters()
     cp.cp = ControlParametersValue()

--- a/src/ndn/transport/dummy_face.py
+++ b/src/ndn/transport/dummy_face.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 import asyncio as aio
+
 from ndn.encoding import parse_tl_num
 from ndn.transport.face import Face
 
@@ -45,6 +46,9 @@ class DummyFace(Face):
         await self.test_func(self)
         if self.app:
             self.app.shutdown()
+
+    def isLocalFace(self):
+        return True
 
     async def consume_output(self, expected_output, timeout=0.01):
         self.expected_len = len(expected_output)

--- a/src/ndn/transport/stream_face.py
+++ b/src/ndn/transport/stream_face.py
@@ -15,10 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # -----------------------------------------------------------------------------
-import io
 import abc
 import asyncio as aio
+import io
 from typing import Optional
+
+from ndn.transport.ip_face import IpFace
+
 from ..encoding.tlv_var import read_tl_num_from_stream
 from ..platform import Platform
 from .face import Face
@@ -62,8 +65,11 @@ class UnixFace(StreamFace):
         self.reader, self.writer = await Platform().open_unix_connection(self.path)
         self.running = True
 
+    def isLocalFace(self):
+        return True
 
-class TcpFace(StreamFace):
+
+class TcpFace(StreamFace, IpFace):
     host: str = '127.0.0.1'
     port: int = 6363
 

--- a/src/ndn/transport/udp_face.py
+++ b/src/ndn/transport/udp_face.py
@@ -20,10 +20,10 @@ import logging
 from typing import Tuple
 
 from ..encoding.tlv_var import parse_tl_num
-from .face import Face
+from .ip_face import IpFace
 
 
-class UdpFace(Face):
+class UdpFace(IpFace):
 
     def __init__(self, host: str = '127.0.0.1', port: int = 6363):
         super().__init__()


### PR DESCRIPTION
Current version of `python-ndn` cannot support remote prefix registration, which means NDNApp can only running with the same server where `nfd` installed, and tools `python-ndn` supplyed cannot only connect with local nfd.
currently I fix `NDNApp` so it can send register prefix to nfd which may not run at the same server with `NDNApp`. I will fix `ndn-tools` latter. 