### PR TITLE
docs: update Python versions on Contribute page

### DIFF
--- a/docs/src/contribute_support.rst
+++ b/docs/src/contribute_support.rst
@@ -2,9 +2,9 @@ Contribute and Support
 ======================
 
 - Please submit any changes via `GitHub`_ pull requests.
-- If you use any existing code, please make sure it is compatible to *Apache v2*
+- If you use any existing code, please make sure it is compatible to *Apache License Version 2.0*
 - Ensure that your code complies to `PEP8`_.
-- Ensure that your code works with *Python 3.6* and *PyPy 7.1.1*.
+- Ensure that your code works with *Python 3.9* and *PyPy 7.3.8*.
 - Please contact the author first if your changes are not back compatible or import new dependencies.
 - Write unit tests. There is no need to cover all code, but please cover as much as you can.
 - Add your name to ``AUTHORS.rst``.


### PR DESCRIPTION
Current library no longer works with Python 3.6.
This PR updates the Python and PyPy versions on "Contribute" page to match README page.