### PR TITLE
MacOS: ignore functions marked as arm64 unavailable

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,6 +6,7 @@ Authors
 * Eric Newberry  <https://ericnewberry.com>
 * Junxiao Shi    <https://yoursunny.com>
 * Tianyuan Yu    <https://www.tianyuan-yu.com/>
+* Alwin Kahlert  <https://github.com/akamos>
 
 Anonymous Contributors
 ======================

--- a/src/ndn/contrib/cocoapy/runtime.py
+++ b/src/ndn/contrib/cocoapy/runtime.py
@@ -40,6 +40,7 @@ from .cocoatypes import *
 
 __LP64__ = (8*struct.calcsize("P") == 64)
 __i386__ = (platform.machine() == 'i386')
+__arm64__ = (platform.machine() == 'arm64')
 
 if sizeof(c_void_p) == 4:
     c_ptrdiff_t = c_int32
@@ -129,9 +130,11 @@ objc.class_getIvarLayout.argtypes = [c_void_p]
 objc.class_getMethodImplementation.restype = c_void_p
 objc.class_getMethodImplementation.argtypes = [c_void_p, c_void_p]
 
-# IMP class_getMethodImplementation_stret(Class cls, SEL name)
-objc.class_getMethodImplementation_stret.restype = c_void_p
-objc.class_getMethodImplementation_stret.argtypes = [c_void_p, c_void_p]
+if not __arm64__:
+    # marked as OBJC_ARM64_UNAVAILABLE
+    # IMP class_getMethodImplementation_stret(Class cls, SEL name)
+    objc.class_getMethodImplementation_stret.restype = c_void_p
+    objc.class_getMethodImplementation_stret.argtypes = [c_void_p, c_void_p]
 
 # const char * class_getName(Class cls)
 objc.class_getName.restype = c_char_p
@@ -278,14 +281,20 @@ objc.objc_getProtocol.argtypes = [c_char_p]
 # id objc_msgSend(id theReceiver, SEL theSelector, ...)
 # id objc_msgSendSuper(struct objc_super *super, SEL op,  ...)
 
-# void objc_msgSendSuper_stret(struct objc_super *super, SEL op, ...)
-objc.objc_msgSendSuper_stret.restype = None
+if not __arm64__:
+    # marked as OBJC_ARM64_UNAVAILABLE
+    # void objc_msgSendSuper_stret(struct objc_super *super, SEL op, ...)
+    objc.objc_msgSendSuper_stret.restype = None
 
-# double objc_msgSend_fpret(id self, SEL op, ...)
-# objc.objc_msgSend_fpret.restype = c_double
+if not __arm64__:
+    # marked as OBJC_ARM64_UNAVAILABLE
+    # double objc_msgSend_fpret(id self, SEL op, ...)
+    objc.objc_msgSend_fpret.restype = c_double
 
-# void objc_msgSend_stret(void * stretAddr, id theReceiver, SEL theSelector,  ...)
-objc.objc_msgSend_stret.restype = None
+if not __arm64__:
+    # marked as OBJC_ARM64_UNAVAILABLE
+    # void objc_msgSend_stret(void * stretAddr, id theReceiver, SEL theSelector,  ...)
+    objc.objc_msgSend_stret.restype = None
 
 # void objc_registerClassPair(Class cls)
 objc.objc_registerClassPair.restype = None


### PR DESCRIPTION
I've tested the library today on Apple Silicon and couldn't start it at first. I've discovered, that some unavailable symbols were imported. 
This PR ignores the imports when the platform is `arm64`. It's inspired by https://github.com/pyglet/pyglet/pull/335

I hope these are all changes needed, as I'm not completely familiar with Objective C bindings in Python. Tests passed all successfully. 

